### PR TITLE
change release name to draft

### DIFF
--- a/bin/draftd.sh
+++ b/bin/draftd.sh
@@ -13,7 +13,7 @@ EOF
 }
 
 destroy() {
-  helm delete draftd --purge
+  helm delete draft --purge
 }
 
 cmd="${1:-}"


### PR DESCRIPTION
The actual release that is created through `draft init` is called `draft` instead of `draftd`. See https://github.com/Azure/draft/blob/5a0ea9b164b7d10dda22249d39ae448382a041d6/cmd/draft/installer/install.go#L212